### PR TITLE
various bugfixes

### DIFF
--- a/ADMF/ADMF.psd1
+++ b/ADMF/ADMF.psd1
@@ -28,8 +28,8 @@
 	RequiredModules = @(
 		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.1.59' }
 		@{ ModuleName = 'DCManagement'; ModuleVersion = '1.0.5' }
-		@{ ModuleName = 'DomainManagement'; ModuleVersion = '1.0.13' }
-		@{ ModuleName = 'ForestManagement'; ModuleVersion = '1.0.7' }
+		@{ ModuleName = 'DomainManagement'; ModuleVersion = '1.0.22' }
+		@{ ModuleName = 'ForestManagement'; ModuleVersion = '1.0.6' }
 	)
 	
 	# Assemblies that must be loaded prior to importing this module

--- a/ADMF/ADMF.psd1
+++ b/ADMF/ADMF.psd1
@@ -3,7 +3,7 @@
 	RootModule = 'ADMF.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.0.0'
+	ModuleVersion = '1.0.6'
 	
 	# ID used to uniquely identify this module
 	GUID = '43f2a890-942f-4dd7-bad0-b774b44ea849'
@@ -27,9 +27,9 @@
 	# this module
 	RequiredModules = @(
 		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.1.59' }
-		@{ ModuleName = 'DCManagement'; ModuleVersion = '1.0.4' }
-		@{ ModuleName = 'DomainManagement'; ModuleVersion = '1.0.11' }
-		@{ ModuleName = 'ForestManagement'; ModuleVersion = '1.0.5' }
+		@{ ModuleName = 'DCManagement'; ModuleVersion = '1.0.5' }
+		@{ ModuleName = 'DomainManagement'; ModuleVersion = '1.0.13' }
+		@{ ModuleName = 'ForestManagement'; ModuleVersion = '1.0.7' }
 	)
 	
 	# Assemblies that must be loaded prior to importing this module

--- a/ADMF/changelog.md
+++ b/ADMF/changelog.md
@@ -1,5 +1,14 @@
 ﻿# Changelog
-## 1.0.0 (2019-12-20)
- - New: Some Stuff
- - Upd: Moar Stuff
- - Fix: Much Stuff
+
+## 1.0.6 (2020-02-18)
+
+- Upd: Get-AdmfContext - New parameter `-Importing` for use within a context's scriptblock.
+- Fix: Set-AdmfContext - No longer re-prompts for context when switching to a new domain with same contexts as previous one.
+- Fix: Set-AdmfContext - Acls from context would not be applied.
+- Fix: All Invoke-* and Test-* commands will now properly prompt for context if needed.
+- Fix: Group Policy Object configuration from contexts is stored with wrong path.
+- Fix: Export-AdmfGpo - removes hidden attribute from all exported files. This attribute prevented application of GPOs, as copy via WinRM will not transfer hidden files.
+
+## 1.0.0 (2019-12-21)
+
+- Initial Upload

--- a/ADMF/changelog.md
+++ b/ADMF/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## 1.0.6 (2020-02-18)
+## 1.0.6 (2020-02-24)
 
 - Upd: Get-AdmfContext - New parameter `-Importing` for use within a context's scriptblock.
 - Fix: Set-AdmfContext - No longer re-prompts for context when switching to a new domain with same contexts as previous one.

--- a/ADMF/functions/Export-AdmfGpo.ps1
+++ b/ADMF/functions/Export-AdmfGpo.ps1
@@ -65,5 +65,10 @@
 	{
 		$backupGPO.End()
 		$gpoData | ConvertTo-Json | Set-Content "$resolvedPath\exportData.json"
+
+		# Remove hidden attribute, top prevent issues with copy over WinRM
+		foreach ($fsItem in (Get-ChildItem -Path $resolvedPath -Recurse -Force)) {
+			$fsItem.Attributes = $fsItem.Attributes -band [System.IO.FileAttributes]::Directory
+		}
 	}
 }

--- a/ADMF/functions/Get-AdmfContext.ps1
+++ b/ADMF/functions/Get-AdmfContext.ps1
@@ -19,6 +19,11 @@
 
 	.PARAMETER Current
 		Displays the currently active contexts.
+
+	.PARAMETER Importing
+		Return the contexts that are currently being imported.
+		Use this to react from within your context's scriptblocks to any other context that is selected.
+		This parameter only has meaning when used within a context's scriptblocks.
 	
 	.EXAMPLE
 		PS C:\> Get-AdmfContext
@@ -41,7 +46,11 @@
 		
 		[Parameter(ParameterSetName = 'Current')]
 		[switch]
-		$Current
+		$Current,
+
+		[Parameter(ParameterSetName = 'Importing')]
+		[switch]
+		$Importing
 	)
 	
 	process
@@ -49,6 +58,10 @@
 		if ($Current)
 		{
 			return $script:loadedContexts
+		}
+		if ($Importing)
+		{
+			return (Get-PSFTaskEngineCache -Module ADMF -Name currentlyImportingContexts)
 		}
 		$contextStores = Get-AdmfContextStore -Name $Store
 		$allContextData = foreach ($contextStore in $contextStores)

--- a/ADMF/functions/Invoke-AdmfDomain.ps1
+++ b/ADMF/functions/Invoke-AdmfDomain.ps1
@@ -76,6 +76,7 @@
 		catch { throw }
 		$parameters.Server = $dcServer
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
+		Set-AdmfContext @parameters -Interactive -ReUse -EnableException
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential, WhatIf, Confirm, Verbose, Debug
 		$parameters.Server = $dcServer
 		[ADMF.UpdateDomainOptions]$newOptions = $Options

--- a/ADMF/functions/Invoke-AdmfForest.ps1
+++ b/ADMF/functions/Invoke-AdmfForest.ps1
@@ -55,6 +55,7 @@
 		catch { throw }
 		$parameters.Server = $dcServer
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
+		Set-AdmfContext @parameters -Interactive -ReUse -EnableException
 		$parameters = $PSBoundParameters | ConvertTo-PSFHashtable -Include Server, Credential, WhatIf, Confirm, Verbose, Debug
 		$parameters.Server = $dcServer
 		[ADMF.UpdateForestOptions]$newOptions = $Options

--- a/ADMF/functions/Test-AdmfDomain.ps1
+++ b/ADMF/functions/Test-AdmfDomain.ps1
@@ -42,6 +42,7 @@
 		try { $parameters.Server = Resolve-DomainController @parameters -ErrorAction Stop }
 		catch { throw }
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
+		Set-AdmfContext @parameters -Interactive -ReUse -EnableException
 		[UpdateDomainOptions]$newOptions = $Options
 	}
 	process

--- a/ADMF/functions/Test-AdmfForest.ps1
+++ b/ADMF/functions/Test-AdmfForest.ps1
@@ -40,6 +40,7 @@
 		try { $parameters.Server = Resolve-DomainController @parameters -ErrorAction Stop }
 		catch { throw }
 		Invoke-PSFCallback -Data $parameters -EnableException $true -PSCmdlet $PSCmdlet
+		Set-AdmfContext @parameters -Interactive -ReUse -EnableException
 		[UpdateForestOptions]$newOptions = $Options
 	}
 	process


### PR DESCRIPTION
- Upd: Get-AdmfContext - New parameter `-Importing` for use within a context's scriptblock.
- Fix: Set-AdmfContext - No longer re-prompts for context when switching to a new domain with same contexts as previous one.
- Fix: Set-AdmfContext - Acls from context would not be applied.
- Fix: All Invoke-* and Test-* commands will now properly prompt for context if needed.
- Fix: Group Policy Object configuration from contexts is stored with wrong path.
- Fix: Export-AdmfGpo - removes hidden attribute from all exported files. This attribute prevented application of GPOs, as copy via WinRM will not transfer hidden files.